### PR TITLE
Add RSS feed auto-scrap workflow

### DIFF
--- a/.claude/commands/rss-to-scrap.md
+++ b/.claude/commands/rss-to-scrap.md
@@ -1,0 +1,22 @@
+$ARGUMENTS RSSフィードURLから新着記事を取得し、scrapを作成してPRを出します
+
+# 入力
+$ARGUMENTS: RSSフィードのURL
+
+# 処理フロー
+
+1. $ARGUMENTS のRSSフィードをWebFetchで取得
+2. XMLをパースし、過去24時間以内に公開された記事を抽出（最大5件）
+3. 各記事について:
+   a. MCPツール `search_scraps` で記事タイトルを検索
+   b. 既存scrapがあればスキップ（「スキップ: {title}」と出力）
+   c. なければ `/web-to-scrap {url}` を実行
+   d. ブランチ作成、コミット、プッシュ
+   e. gh pr create でPR作成
+4. 処理結果のサマリーを出力
+
+# 注意事項
+
+- 記事ごとに別ブランチ・別PRを作成
+- ブランチ名: rss-scrap/{タイトルのslug}
+- 既存scrapとの重複チェックは必須

--- a/.github/workflows/rss-kubernetes-blog.yml
+++ b/.github/workflows/rss-kubernetes-blog.yml
@@ -1,0 +1,13 @@
+name: RSS - Kubernetes Blog
+
+on:
+  schedule:
+    - cron: '0 9 * * *'  # 毎日18:00 JST
+  workflow_dispatch:
+
+jobs:
+  rss-to-scrap:
+    uses: ./.github/workflows/rss-to-scrap-reusable.yml
+    with:
+      feed_url: 'https://kubernetes.io/feed.xml'
+      max_articles: 5

--- a/.github/workflows/rss-to-scrap-reusable.yml
+++ b/.github/workflows/rss-to-scrap-reusable.yml
@@ -1,0 +1,27 @@
+name: RSS to Scrap (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      feed_url:
+        description: 'URL of the RSS feed'
+        required: true
+        type: string
+      max_articles:
+        description: 'Maximum number of articles to process'
+        required: false
+        type: number
+        default: 5
+
+jobs:
+  process-feed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Process RSS feed
+        uses: anthropics/claude-code-action@v1
+        with:
+          prompt: /rss-to-scrap ${{ inputs.feed_url }}
+          claude_args: |
+            --max-turns 50


### PR DESCRIPTION
## Summary

- Add `/rss-to-scrap` command for Claude Code to process RSS feeds
- Add reusable workflow (`rss-to-scrap-reusable.yml`) that can be called by multiple feed-specific workflows
- Add Kubernetes blog caller workflow that runs daily at 18:00 JST

## Architecture

```
Caller Workflows (rss-kubernetes-blog.yml, etc.)
        │
        ▼
Reusable Workflow (rss-to-scrap-reusable.yml)
        │
        ▼
Claude Code Action → /rss-to-scrap command
```

## Test plan

- [ ] Manually trigger `rss-kubernetes-blog.yml` via workflow_dispatch
- [ ] Verify RSS feed is fetched and parsed correctly
- [ ] Verify duplicate check with `search_scraps` works
- [ ] Verify PRs are created for new articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)