### PR TITLE
Add scrap: Kubernetes/Security

### DIFF
--- a/scraps/Kubernetes/Security.md
+++ b/scraps/Kubernetes/Security.md
@@ -1,0 +1,14 @@
+#[[Security]] #[[Kubernetes]]
+
+[[Kubernetes]]クラスタとワークロードを保護するためのセキュリティ対策の総称
+
+4Csセキュリティモデルに基づき、Cloud、Cluster、Container、Codeの各レイヤーで多層防御を実装する
+
+主なセキュリティ機能:
+
+- アクセス制御: [[Kubernetes/ServiceAccount]]、[[Kubernetes/Role]]、[[RBAC]]
+- Pod保護: [[Kubernetes/Security Context]]、[[Kubernetes/Pod Security Standards]]、[[Kubernetes/Pod Security Admission]]
+- ネットワーク: [[Kubernetes/Network policy]]、[[サービスメッシュ]]
+- シークレット管理: [[Kubernetes/Secret]]
+
+<https://kubernetes.io/docs/concepts/security/>


### PR DESCRIPTION
## Summary

- Add new scrap for Kubernetes/Security overview
- Covers 4Cs security model (Cloud, Cluster, Container, Code)
- Links to related security features: ServiceAccount, RBAC, Pod Security, Network Policy, Secrets

## Test plan

- [ ] Verify the scrap renders correctly
- [ ] Check all wiki-links resolve properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)