### PR TITLE
Add scrap: X-Frame-Options

### DIFF
--- a/scraps/X-Frame-Options.md
+++ b/scraps/X-Frame-Options.md
@@ -1,0 +1,15 @@
+#[[Security]] #[[Network]]
+
+クリックジャッキング攻撃を防ぐための[[HTTP]]レスポンスヘッダー
+
+ページが`<frame>`、`<iframe>`、`<embed>`、`<object>`内で表示されることを制御する
+
+設定値は以下の3つ
+
+- DENY: すべてのフレーム表示を禁止
+- SAMEORIGIN: 同一オリジンのみフレーム表示を許可
+- ALLOW-FROM URI: 特定のURIからのフレーム表示を許可（非推奨）
+
+現在はCSPの`frame-ancestors`ディレクティブの使用が推奨されている
+
+<https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options>


### PR DESCRIPTION
## Summary
- X-Frame-Options HTTPレスポンスヘッダーのスクラップを追加
- クリックジャッキング攻撃防止のためのセキュリティヘッダー
- DENY、SAMEORIGIN、ALLOW-FROM URIの3つの設定値を説明

## Test plan
- [ ] lintエラーがないこと
- [ ] ビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)