### PR TITLE
Switch scraps installation from cargo to github backend

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,7 @@ jobs:
         uses: jdx/mise-action@v2
 
       - name: Install scraps
-        run: mise install cargo:scraps
+        run: mise install github:boykush/scraps
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/create-scrap-from-issue.yml
+++ b/.github/workflows/create-scrap-from-issue.yml
@@ -23,7 +23,7 @@ jobs:
         uses: jdx/mise-action@v2
 
       - name: Install scraps
-        run: mise install cargo:scraps
+        run: mise install github:boykush/scraps
 
       - name: Run Claude with add-scrap skill
         uses: anthropics/claude-code-action@v1

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,6 @@
 [tools]
 "npm:markdownlint-cli2" = "latest"
-"cargo:scraps" = "latest"
-rust = "latest"
+"github:boykush/scraps" = "latest"
 
 [tasks.build]
 description = "Build static site from Markdown files"


### PR DESCRIPTION
プリビルドバイナリのダウンロードに切り替えることで、
Rustコンパイラによるソースビルドが不要になり、インストールが高速化される

https://claude.ai/code/session_01BAY56fZNiYbhCmGkuwY5GR