### PR TITLE
Update jdx/mise-action from v2 to v3

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v3
 
       - name: Install scraps
         run: mise install cargo:scraps

--- a/.github/workflows/create-scrap-from-issue.yml
+++ b/.github/workflows/create-scrap-from-issue.yml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup mise
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v3
 
       - name: Install scraps
         run: mise install cargo:scraps


### PR DESCRIPTION
v2 is no longer supported and fails with exit code 2 on current
GitHub Actions runners. The current supported version is v3.

https://claude.ai/code/session_01RMTRwsjH6w9iJEpFEiy4Wk