### PR TITLE
Add RSS-to-scrap PR automation

### DIFF
--- a/.github/rss-to-scrap/feeds.yml
+++ b/.github/rss-to-scrap/feeds.yml
@@ -1,0 +1,4 @@
+# RSS feeds to ingest into the wiki.
+# Each entry is a URL string. Use a trailing `# name` comment to label each feed.
+feeds:
+  - https://github.blog/category/security/feed/   # GitHub Security Blog

--- a/.github/workflows/rss-to-scrap.yml
+++ b/.github/workflows/rss-to-scrap.yml
@@ -1,0 +1,96 @@
+name: RSS to Scrap PR
+
+on:
+  schedule:
+    - cron: '0 23 * * *'  # 08:00 JST daily (target = previous JST day)
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'Target date (YYYY-MM-DD, JST). Default: yesterday.'
+        required: false
+
+jobs:
+  list-articles:
+    runs-on: ubuntu-latest
+    outputs:
+      articles: ${{ steps.fetch.outputs.articles }}
+      count: ${{ steps.fetch.outputs.count }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: jdx/mise-action@v4
+
+      - id: fetch
+        env:
+          DATE_INPUT: ${{ inputs.date }}
+        run: |
+          if [ -n "$DATE_INPUT" ]; then
+            ARTICLES=$(mise run fetch-rss -- --date "$DATE_INPUT")
+          else
+            ARTICLES=$(mise run fetch-rss)
+          fi
+          {
+            echo "articles<<RSSEOF"
+            echo "$ARTICLES"
+            echo "RSSEOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "count=$(echo "$ARTICLES" | jq 'length')" >> "$GITHUB_OUTPUT"
+
+  create-scrap:
+    needs: list-articles
+    if: needs.list-articles.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        article: ${{ fromJson(needs.list-articles.outputs.articles) }}
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: jdx/mise-action@v4
+
+      - name: Run Claude with web-to-scrap skill
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: |
+            https://github.com/boykush/scraps.git
+          plugins: |
+            scraps-writer@scraps-claude-code-plugins
+          settings: ".claude/settings.json"
+          prompt: |
+            /web-to-scrap ${{ matrix.article.url }}
+
+      - name: Create Pull Request
+        env:
+          ARTICLE_TITLE: ${{ matrix.article.title }}
+          ARTICLE_URL: ${{ matrix.article.url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+
+          URL_HASH=$(printf '%s' "$ARTICLE_URL" | sha1sum | cut -c1-8)
+          BRANCH_NAME="add-scrap/rss-${URL_HASH}-${{ github.run_id }}"
+          git checkout -b "$BRANCH_NAME"
+
+          git add scraps/
+          if git diff --cached --quiet; then
+            echo "No changes to commit (web-to-scrap may have skipped)"
+            exit 0
+          fi
+          git commit -m "Add scrap from RSS: ${ARTICLE_TITLE}"
+          git push origin "$BRANCH_NAME"
+
+          gh pr create \
+            --title "Add scrap from RSS: ${ARTICLE_TITLE}" \
+            --body "Source: ${ARTICLE_URL}" \
+            --base main

--- a/.github/workflows/rss-to-scrap.yml
+++ b/.github/workflows/rss-to-scrap.yml
@@ -2,7 +2,7 @@ name: RSS to Scrap PR
 
 on:
   schedule:
-    - cron: '0 23 * * *'  # 08:00 JST daily (target = previous JST day)
+    - cron: '0 0 * * *'  # 09:00 JST daily (target = previous JST day)
   workflow_dispatch:
     inputs:
       date:

--- a/mise-tasks/fetch-rss
+++ b/mise-tasks/fetch-rss
@@ -1,0 +1,69 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["feedparser", "pyyaml"]
+# ///
+"""Fetch RSS feed entries published on a target date.
+
+Reads `.github/rss-to-scrap/feeds.yml` and prints a JSON array of articles
+to stdout. Each entry has `url` and `title`. Defaults to yesterday in JST
+when --date is omitted.
+
+Usage:
+    mise run fetch-rss [-- --date YYYY-MM-DD]
+"""
+import argparse
+import datetime
+import json
+import sys
+import zoneinfo
+from pathlib import Path
+
+import feedparser
+import yaml
+
+JST = zoneinfo.ZoneInfo("Asia/Tokyo")
+CONFIG_PATH = Path(".github/rss-to-scrap/feeds.yml")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--date", help="Target date YYYY-MM-DD (JST). Default: yesterday.")
+    return p.parse_args()
+
+
+def resolve_date(arg: str | None) -> datetime.date:
+    if arg:
+        return datetime.date.fromisoformat(arg)
+    return (datetime.datetime.now(JST) - datetime.timedelta(days=1)).date()
+
+
+def entry_date_jst(entry) -> datetime.date | None:
+    for key in ("published_parsed", "updated_parsed"):
+        t = getattr(entry, key, None)
+        if t:
+            dt = datetime.datetime(*t[:6], tzinfo=datetime.timezone.utc)
+            return dt.astimezone(JST).date()
+    return None
+
+
+def main() -> None:
+    args = parse_args()
+    target = resolve_date(args.date)
+
+    config = yaml.safe_load(CONFIG_PATH.read_text()) or {}
+    feeds = config.get("feeds") or []
+
+    articles = []
+    for feed_url in feeds:
+        parsed = feedparser.parse(feed_url)
+        for entry in parsed.entries:
+            if entry_date_jst(entry) == target:
+                articles.append({"url": entry.link, "title": entry.title})
+
+    json.dump(articles, sys.stdout, ensure_ascii=False)
+    print(f"target_date={target}, found={len(articles)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 "npm:markdownlint-cli2" = "latest"
 "github:boykush/scraps" = "latest"
+uv = "latest"
 
 [tasks.build]
 description = "Build static site from Markdown files"


### PR DESCRIPTION
## Summary
- Daily workflow (08:00 JST) fetches articles from configured RSS feeds for the previous JST day
- Each article is summarized via `/web-to-scrap` and proposed as its own PR
- Feed list lives in `.github/rss-to-scrap/feeds.yml` (initial: GitHub Security Blog)
- Stateless: re-runs accept a `date` input via `workflow_dispatch`

## Test plan
- [ ] Run `workflow_dispatch` with `date=2026-04-29` (known to have 1 article) and confirm a PR is opened
- [ ] Verify the produced scrap follows existing conventions
- [ ] Confirm next scheduled run fires at 08:00 JST and behaves correctly with 0-article days

Refs: boykush/career#87

🤖 Generated with [Claude Code](https://claude.com/claude-code)