### PR TITLE
Add SessionStart hook to install mise in remote environments

### DIFF
--- a/.claude/hooks/setup-remote.sh
+++ b/.claude/hooks/setup-remote.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+# Only run in remote cloud environments
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+  exit 0
+fi
+
+# Install mise if not present
+if ! command -v mise &> /dev/null; then
+  echo "Installing mise..."
+  mkdir -p "$HOME/.local/bin"
+
+  # Download pre-built binary directly from GitHub Releases
+  # (mise.jdx.dev/install.sh is blocked in some remote environments)
+  case "$(uname -m)" in
+    x86_64)  local_arch="x64" ;;
+    aarch64) local_arch="arm64" ;;
+    *)       local_arch="$(uname -m)" ;;
+  esac
+  mise_version=$(curl -fsSI "https://github.com/jdx/mise/releases/latest" 2>&1 \
+    | grep -i location | sed 's/.*tag\///' | tr -d '\r\n')
+  curl -fsSL -o "$HOME/.local/bin/mise" \
+    "https://github.com/jdx/mise/releases/download/${mise_version}/mise-${mise_version}-linux-${local_arch}"
+  chmod +x "$HOME/.local/bin/mise"
+
+  if [ -n "$CLAUDE_ENV_FILE" ]; then
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$CLAUDE_ENV_FILE"
+  fi
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# Install tools defined in mise configuration.
+# Resolving tool versions requires api.github.com; if the environment's
+# network policy blocks it, this step is skipped with a warning rather
+# than failing the whole setup.
+echo "Running mise install..."
+mise trust
+if ! mise install; then
+  echo "WARN: mise install failed (api.github.com may be blocked by the network policy)." >&2
+fi
+
+echo "Remote setup complete."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,5 +15,19 @@
     "allow": [
       "Bash(scraps:*)"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/setup-remote.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Claude Code のクラウド（リモート）環境セットアップ時に mise を自動導入する `SessionStart` フックを追加
- scraps リポジトリ（`boykush/scraps`）の `setup-remote.sh` と同じ方式を踏襲
- `mise.jdx.dev/install.sh` や `crates.io` がネットワークポリシーでブロックされるため、GitHub Releases のバイナリを直接ダウンロードして `$HOME/.local/bin` に配置 → `$CLAUDE_ENV_FILE` で PATH を通す

## 詳細
- `.claude/hooks/setup-remote.sh`: `CLAUDE_CODE_REMOTE=true` のときのみ実行。mise 未導入なら release バイナリを取得し、`mise trust && mise install` を実行
- `.claude/settings.json`: `SessionStart`(matcher: `startup`) フックを登録（timeout 300s）
- scraps 版との差分: `mise install` を非致命扱いにしている。この wiki 環境では `api.github.com` がネットワークポリシーでブロックされており（403）、ツールのバージョン解決に失敗するため、セッション起動自体を落とさず WARN のみ出す

## 既知の制約
- mise 本体の導入（github.com 経由）は成功するが、`mise install` での scraps / uv の取得は `api.github.com` への到達が必要。現在のこの環境のネットワークポリシーでは取得不可。環境側で `api.github.com` を許可リストに追加すれば完全に動作する

## Test plan
- [x] `python3 -c json.load` で settings.json の妥当性確認
- [x] `bash -n` で hook のシンタックス確認
- [x] `CLAUDE_CODE_REMOTE=true` で hook を実行し、mise 導入 → install 失敗時も exit 0 で完走することを確認
- [ ] `api.github.com` 到達可能な環境で `mise install` まで成功することの確認

https://claude.ai/code/session_015dCHVHjwShKNTgKZu5Us1J

---
_Generated by [Claude Code](https://claude.ai/code/session_015dCHVHjwShKNTgKZu5Us1J)_