### PR TITLE
Remove unused uv tool to avoid GitHub API rate limit on setup

### DIFF
--- a/.claude/hooks/setup-remote.sh
+++ b/.claude/hooks/setup-remote.sh
@@ -30,14 +30,14 @@ if ! command -v mise &> /dev/null; then
   export PATH="$HOME/.local/bin:$PATH"
 fi
 
-# Install tools defined in mise configuration.
-# Resolving tool versions requires api.github.com; if the environment's
-# network policy blocks it, this step is skipped with a warning rather
-# than failing the whole setup.
+# Install tools defined in mise configuration. Only scraps (pinned, one
+# tag lookup) touches api.github.com; markdownlint comes from npm. Keeping
+# the config lean avoids exhausting the 60 req/hour limit for unauthenticated
+# api.github.com access. If that limit is hit anyway, warn rather than fail.
 echo "Running mise install..."
 mise trust
 if ! mise install; then
-  echo "WARN: mise install failed (api.github.com may be blocked by the network policy)." >&2
+  echo "WARN: mise install failed (api.github.com rate limit or blocked by the network policy)." >&2
 fi
 
 echo "Remote setup complete."

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,6 @@
 [tools]
 "npm:markdownlint-cli2" = "latest"
 "github:boykush/scraps" = "v1.0.0"
-uv = "latest"
 
 [env]
 SCRAPS_DIRECTORY = "{{config_root}}/scraps"


### PR DESCRIPTION
## Summary

リモート環境の setup（SessionStart フック）で `mise install` が実質失敗していた問題への対応です。

- **原因**: `GITHUB_TOKEN` 未設定のため GitHub API への未認証アクセスとなり、上限が **60 req/hour**。`mise.toml` の `uv = "latest"` が `latest` 解決のために astral-sh/uv のリリース一覧取得を繰り返し、この枠を使い切る。結果、後続の `github:boykush/scraps@v1.0.0` 取得まで `403 Forbidden` で失敗し、wiki に必須の `scraps` CLI が入らなかった。
- `uv` はどのタスク・skill・workflow でも未使用（`mise.toml` の1行のみ）だったため削除。
- これで setup 時に GitHub API を叩くのは **固定版 scraps のタグ参照1回のみ**。`markdownlint-cli2` は npm 経由で GitHub API 不使用。
- `setup-remote.sh` のコメントを実態に合わせて更新（warning 文言にレート制限も明記）。

## Test plan

- [ ] レート制限リセット後にクリーンな環境で `mise install` を実行し、`scraps` が `(missing)` でなくインストールされることを確認
- [ ] `mise exec -- scraps --version` が成功する
- [ ] `mise tasks`（build / serve / lint）が解決できる

https://claude.ai/code/session_01Dy4dRSJmqSWAX2W5AVjjGo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy4dRSJmqSWAX2W5AVjjGo)_