### PR TITLE
Install scraps via cargo backend in remote setup

### DIFF
--- a/.claude/hooks/setup-remote.sh
+++ b/.claude/hooks/setup-remote.sh
@@ -30,14 +30,25 @@ if ! command -v mise &> /dev/null; then
   export PATH="$HOME/.local/bin:$PATH"
 fi
 
-# Install tools defined in mise configuration. Only scraps (pinned, one
-# tag lookup) touches api.github.com. Keeping the config lean avoids
-# exhausting the 60 req/hour limit for unauthenticated api.github.com
-# access. If that limit is hit anyway, warn rather than fail.
+# Pin MISE_ENV=remote so mise loads mise.remote.toml in addition to the base
+# config. That overlay installs scraps via the cargo backend (crates.io build),
+# avoiding api.github.com which is blocked / rate-limited here. The base github
+# backend stays declared but its install attempt 403s harmlessly; once cargo
+# finishes, `mise which scraps` resolves to it. Persist MISE_ENV so the rest of
+# the session (build/serve tasks) keeps resolving the cargo build too.
+export MISE_ENV=remote
+if [ -n "$CLAUDE_ENV_FILE" ]; then
+  echo 'export MISE_ENV=remote' >> "$CLAUDE_ENV_FILE"
+fi
+
 echo "Running mise install..."
 mise trust
-if ! mise install; then
-  echo "WARN: mise install failed (api.github.com rate limit or blocked by the network policy)." >&2
+# mise install returns non-zero because the base github backend always 403s
+# here; that is expected. What matters is the cargo build, so judge success by
+# whether scraps actually resolves rather than by the install exit code.
+mise install || true
+if ! mise which scraps >/dev/null 2>&1; then
+  echo "WARN: scraps unavailable after mise install (cargo build or network policy)." >&2
 fi
 
 echo "Remote setup complete."

--- a/mise.remote.toml
+++ b/mise.remote.toml
@@ -1,0 +1,8 @@
+# Config environment overlay for remote Claude Code sessions (MISE_ENV=remote).
+# The base mise.toml pins scraps via the github backend (fast prebuilt binary
+# for local dev). In remote sessions api.github.com is blocked / rate-limited,
+# so we additionally install scraps from crates.io via the cargo backend. Both
+# entries stay active; `mise which scraps` resolves to whichever installed, so
+# the cargo build wins even though the github lookup fails.
+[tools]
+"cargo:scraps" = "1.0.0"


### PR DESCRIPTION
Remote Claude Code sessions have api.github.com blocked / rate-limited,
so the github backend used for local dev cannot resolve scraps. Add a
mise.remote.toml overlay that installs scraps from crates.io via the
cargo backend, and pin MISE_ENV=remote in the setup hook so it is loaded
during install and persisted for the session's build/serve tasks.

https://claude.ai/code/session_015e7cBGiVzThwhWh7yDxDFC