### PR TITLE
Align CLAUDE.md/AGENTS.md with scraps plugin v0.1.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## LLM Wiki schema
 
-Scraps の **default LLM Wiki schema** は `scraps:scraps-llm-wiki-schema` agent が提供する。Andrej Karpathy の [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) を Scraps 向けに grounding し、`/ingest` / `/query` / `scraps:lint-rule-handler` への意図ルーティングと公式 Doc ベースのツール解説を担う。このファイルは default schema への **ローカル拡張**としてリポジトリ固有の運用規約のみを記述する。
+Scraps の **default LLM Wiki schema** は `scraps:scraps-llm-wiki-schema` agent が提供する。Andrej Karpathy の [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) を Scraps 向けに grounding し、`/ingest` / `/query` / `scraps:lint-rule-handler` への意図ルーティング、対話レイヤー（catch-up・取り込み前の検討）、公式 Doc ベースのツール解説を担う。このファイルは default schema への **ローカル拡張**としてリポジトリ固有の運用規約のみを記述する。
 
 ## アーキテクチャ
 
@@ -29,10 +29,9 @@ Scraps の **default LLM Wiki schema** は `scraps:scraps-llm-wiki-schema` agent
 
 ## Scrap 記述のローカル規約
 
-- **必ず `/ingest` skill 経由で作成**。関連 scrap を `/query` で確認してから ingest する流れも可
-- **リンクの向き**: 具体→抽象、実装→概念の片方向（例: 書籍→概念 OK、概念→書籍 NG）
+- **必ず `/ingest` skill 経由で作成**。`/query` での確認や `scraps:scraps-llm-wiki-schema` agent での議論（catch-up・取り込み前の検討）を挟んでから ingest する流れも可
+- **リンク／相互リンクの規律は default schema に委譲**: 向き（具体→抽象の片方向）・既存言及のみのリンク化・関連の捏造禁止は `/ingest` の cross-link step が定義する。ローカルでは再記述しない
 - **概念 scrap は "それが何か" に絞る**: use case 列挙（「X 対策にも、Y 管理にも、Z にも使える」）は anti-pattern。具体側からの backlink に任せる
-- **「たまたま使われる」程度の弱い関連は wiki-link しない**: 直接の依存・所属・派生でない関係は plain text のままに留める
 - **検証済み事実のみ記述**: 製品カテゴリ自称や他製品との比較は公式 source で明示確認できた範囲のみ。「ソースに書かれていない」は「そうではない」の根拠にならない (absence ≠ negative fact)
 - **タグにエイリアス不可**: v1 のタグは discriminator。`#[[Tag|alias]]` 形式は scrap link 専用
 - **本文構成**: 略語があれば冒頭 h2 (`## XYZ`)、続いてタグ行 (`#[[A]] #[[B]]`)、本文（概要 1–2 文＋箇条書き、関連は wiki-link、外部 URL は autolink）。詳細形式と例は公式 Doc 参照

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## LLM Wiki schema
 
-Scraps の **default LLM Wiki schema** は `scraps:scraps-llm-wiki-schema` agent が提供する。Andrej Karpathy の [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) を Scraps 向けに grounding し、`/ingest` / `/query` / `scraps:lint-rule-handler` への意図ルーティングと公式 Doc ベースのツール解説を担う。このファイルは default schema への **ローカル拡張**としてリポジトリ固有の運用規約のみを記述する。
+Scraps の **default LLM Wiki schema** は `scraps:scraps-llm-wiki-schema` agent が提供する。Andrej Karpathy の [LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) を Scraps 向けに grounding し、`/ingest` / `/query` / `scraps:lint-rule-handler` への意図ルーティング、対話レイヤー（catch-up・取り込み前の検討）、公式 Doc ベースのツール解説を担う。このファイルは default schema への **ローカル拡張**としてリポジトリ固有の運用規約のみを記述する。
 
 ## アーキテクチャ
 
@@ -24,10 +24,9 @@ Scraps の **default LLM Wiki schema** は `scraps:scraps-llm-wiki-schema` agent
 
 ## Scrap 記述のローカル規約
 
-- **必ず `/ingest` skill 経由で作成**。関連 scrap を `/query` で確認してから ingest する流れも可
-- **リンクの向き**: 具体→抽象、実装→概念の片方向（例: 書籍→概念 OK、概念→書籍 NG）
+- **必ず `/ingest` skill 経由で作成**。`/query` での確認や `scraps:scraps-llm-wiki-schema` agent での議論（catch-up・取り込み前の検討）を挟んでから ingest する流れも可
+- **リンク／相互リンクの規律は default schema に委譲**: 向き（具体→抽象の片方向）・既存言及のみのリンク化・関連の捏造禁止は `/ingest` の cross-link step が定義する。ローカルでは再記述しない
 - **概念 scrap は "それが何か" に絞る**: use case 列挙（「X 対策にも、Y 管理にも、Z にも使える」）は anti-pattern。具体側からの backlink に任せる
-- **「たまたま使われる」程度の弱い関連は wiki-link しない**: 直接の依存・所属・派生でない関係は plain text のままに留める
 - **検証済み事実のみ記述**: 製品カテゴリ自称や他製品との比較は公式 source で明示確認できた範囲のみ。「ソースに書かれていない」は「そうではない」の根拠にならない (absence ≠ negative fact)
 - **タグにエイリアス不可**: v1 のタグは discriminator。`#[[Tag|alias]]` 形式は scrap link 専用
 - **本文構成**: 略語があれば冒頭 h2 (`## XYZ`)、続いてタグ行 (`#[[A]] #[[B]]`)、本文（概要 1–2 文＋箇条書き、関連は wiki-link、外部 URL は autolink）。詳細形式と例は公式 Doc 参照


### PR DESCRIPTION
## 概要

scraps AI プラグイン **v0.1.4** の更新に合わせて、wiki の `CLAUDE.md` / `AGENTS.md` を整合させる。両ファイルは同期対象なので同一の調整を入れている。

## なぜ

v0.1.4 で plugin 側に次の変化があり、`CLAUDE.md` の一部ローカル規約が default schema と重複した。

- `/ingest` の **cross-link step** が「具体→抽象の片方向」「本文の既存言及のみリンク化・関連を捏造しない」を明文化（commit `250cc75` / `612e221`）
- `scraps-llm-wiki-schema` agent が **対話レイヤー**（catch-up・取り込み前の検討。primitives は silent one-shot に保つ）を明示

両ファイルは自ら「default schema への**ローカル拡張**として repo 固有の運用規約**のみ**を記述する」と宣言しているため、重複分は default schema へ委譲するのが筋。

## 変更点

- **LLM Wiki schema セクション**: agent の役割に対話レイヤー（catch-up・取り込み前の検討）を追記
- **Scrap 記述のローカル規約**:
  - 重複2項目「リンクの向き（具体→抽象）」＋「弱い関連は wiki-link しない」を、`/ingest` の cross-link step に委譲する1行ポインタへ集約
  - `必ず /ingest 経由` の項に schema agent での議論フローを追記
  - repo 固有ルール（概念 scrap / 検証済み事実 / タグにエイリアス不可 / 本文構成）は維持

## レビュアー向けメモ

- ローカルの marketplace チェックアウトはセッション時点で古い版（≈v0.1.2）がロードされていた。本 PR は `origin/main` の v0.1.4 を正として整合済み。実プラグインの最新化は別途 marketplace 更新が必要。
- `scraps-migration` プラグイン（v0.1.4 期に追加）は wiki 移行用で本 wiki の執筆ルールに関与しないため、ドキュメントには反映していない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)