### PR TITLE
Bump claude-code-action to v1.0.133 and scraps to v1.0.1

### DIFF
--- a/.github/workflows/create-scrap-from-issue.yml
+++ b/.github/workflows/create-scrap-from-issue.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run Claude with ingest skill
         env:
           SCRAPS_DIRECTORY: scraps
-        uses: anthropics/claude-code-action@0630ef383a451c46ccac86eb86ee7641e99c4c9a # v1.0.0
+        uses: anthropics/claude-code-action@db614ad5ed8c94def23ad6cc336751c8ba450ac1 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: |

--- a/.github/workflows/rss-to-scrap.yml
+++ b/.github/workflows/rss-to-scrap.yml
@@ -58,7 +58,7 @@ jobs:
         uses: boykush/scraps@a8bf05b091898d347535c052707d7b77b2a74274 # v1.0.1
 
       - name: Run Claude with ingest skill
-        uses: anthropics/claude-code-action@0630ef383a451c46ccac86eb86ee7641e99c4c9a # v1.0.0
+        uses: anthropics/claude-code-action@db614ad5ed8c94def23ad6cc336751c8ba450ac1 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: |

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-"github:boykush/scraps" = "v1.0.0"
+"github:boykush/scraps" = "v1.0.1"
 uv = "latest"
 
 [env]


### PR DESCRIPTION
## 背景

GitHub Actions の ingest ワークフロー（[run 26704787112](https://github.com/boykush/wiki/actions/runs/26704787112)）で PR が作成されない事象を調査した結果、`anthropics/claude-code-action@v1.0.0` が `plugins` / `plugin_marketplaces` 入力をサポートしておらず、scraps プラグイン（`/ingest` skill）がロードされていなかったことが原因と判明した。

ログでは `Unexpected input(s) 'plugin_marketplaces', 'plugins'` の警告が出ており、Claude は「`/ingest` skill is not installed」と判断して scrap を生成せず、`git add scraps/` に差分がないため `No changes to commit` で正常終了 → PR 未作成となっていた。

## 変更内容

- `claude-code-action` を `v1.0.0` → `v1.0.133`（`plugins` / `plugin_marketplaces` 入力をサポートするバージョン）
  - `.github/workflows/create-scrap-from-issue.yml`
  - `.github/workflows/rss-to-scrap.yml`
- `mise.toml` の `boykush/scraps` を `v1.0.0` → `v1.0.1`（ワークフローの Setup Scraps と整合）

## 確認

- ローカル CLI: `scraps 1.0.1` で動作確認済み
- ワークフローの動作確認は Issue に `ingest` ラベルを付け直すことで検証可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)