### PR TITLE
claude.yml で plugin skill（Skill ツール）を利用可能にする

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,3 +42,4 @@ jobs:
           plugins: |
             scraps@scraps-claude-code-plugins
           settings: ".claude/settings.json"
+          claude_args: --allowed-tools "WebFetch,Read,Write,Edit,Glob,Bash,Skill"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         uses: boykush/scraps@a8bf05b091898d347535c052707d7b77b2a74274 # v1.0.1
 
       - name: Run Claude Code
-        uses: anthropics/claude-code-action@db614ad5ed8c94def23ad6cc336751c8ba450ac1 # v1.0.133
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: |


### PR DESCRIPTION
## 背景

`@claude` メンション対応ワークフロー `claude.yml` では、`plugin_marketplaces` / `plugins` / `settings` の指定で scraps プラグイン自体は読み込まれているものの、`claude_args` が無いため `Skill` ツールが allowed-tools に含まれず、プラグインの skill（`/ingest` 等）を起動できない状態だった。

実例として [run 26716189941](https://github.com/boykush/wiki/actions/runs/26716189941) では、@claude メンションへの応答が素の Edit で処理され、scraps skill にはルーティングされていなかった。

## 変更

ingest 系ワークフロー（`rss-to-scrap.yml` / `create-scrap-from-issue.yml`）と揃えて、`Run Claude Code` ステップに以下を追加:

```yaml
claude_args: --allowed-tools "WebFetch,Read,Write,Edit,Glob,Bash,Skill"
```

これにより @claude メンション時もプラグイン skill を利用できるようになる。

https://claude.ai/code/session_019Qt22Yry1SvdBEEt5DrkpC

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qt22Yry1SvdBEEt5DrkpC)_