### PR TITLE
Add safe-settings scrap

### DIFF
--- a/scraps/safe-settings.md
+++ b/scraps/safe-settings.md
@@ -1,0 +1,10 @@
+#[[Continuous Integration]]
+
+リポジトリ設定を policy-as-code で組織横断に宣言・適用する [[GitHub]] App（Probot ベース）。admin リポジトリに設定を集中管理し、各 repo の実設定を GitHub API 経由で宣言状態へ収束させる、repo 設定版の [[Infrastructure as Code]]。[[Platform Engineering]] の guardrails 実装の一つ
+
+- 設定は admin repo の 3 階層（`.github/settings.yml`=org / `suborgs/*.yml` / `repos/*.yml`）で各 repo にマージ適用、優先度は repo > suborg > org
+- full sync（CRON）で drift を検出・修正、PR では nop モードで dry-run 差分を提示
+- 管理対象は GitHub API で扱う設定のみ（branch protection / labels / collaborators / teams / topics / custom properties / environments / rulesets 等）。**ファイル内容は扱えず** `.github/workflows/*.yml` の配布はできない（[[GitHub Actions]] の強制は ruleset / required workflows 経由）
+- **Organization 専用**で個人アカウントでは動かない
+
+<https://github.com/github/safe-settings>

--- a/scraps/safe-settings.md
+++ b/scraps/safe-settings.md
@@ -1,6 +1,6 @@
 #[[Continuous Integration]]
 
-リポジトリ設定を policy-as-code で組織横断に宣言・適用する [[GitHub]] App（Probot ベース）。admin リポジトリに設定を集中管理し、各 repo の実設定を GitHub API 経由で宣言状態へ収束させる、repo 設定版の [[Infrastructure as Code]]。[[Platform Engineering]] の guardrails 実装の一つ
+リポジトリ設定を policy-as-code で組織横断に宣言・適用する [[GitHub App]]（Probot ベース）。admin リポジトリに設定を集中管理し、各 repo の実設定を GitHub API 経由で宣言状態へ収束させる、repo 設定版の [[Infrastructure as Code]]。[[Platform Engineering]] の guardrails 実装の一つ
 
 - 設定は admin repo の 3 階層（`.github/settings.yml`=org / `suborgs/*.yml` / `repos/*.yml`）で各 repo にマージ適用、優先度は repo > suborg > org
 - full sync（CRON）で drift を検出・修正、PR では nop モードで dry-run 差分を提示


### PR DESCRIPTION
## 概要

`github/safe-settings`（policy-as-code でリポジトリ設定を組織横断に適用する GitHub App）の scrap を1件追加。

複数リポジトリの横断標準化・ガバナンス手段の catch-up（`/query` で既存 wiki を確認 → `/ingest`）の成果物。

## 内容

- `scraps/safe-settings.md` を新規追加（「それが何か」に絞った概念 scrap）
- 能力境界を本文に明記:
  - 管理対象は GitHub API で扱う設定のみ（branch protection / labels / teams / custom properties / environments / rulesets 等）
  - **ファイル内容は扱えない** — `.github/workflows/*.yml`（caller）の配布は不可、Actions 強制は ruleset / required workflows 経由
  - **Organization 専用**（個人アカウント不可）
- リンク（concrete→abstract）: `[[Infrastructure as Code]]` / `[[Platform Engineering]]` / `[[GitHub]]` / `[[GitHub Actions]]`
- タグ: `#[[Continuous Integration]]`

## 確認

- broken-link lint: 新規 scrap 0 件（既存の無関係警告 `[[IAM]]` は本 PR 対象外）
- 4 つの out-link はすべて解決確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)