### PR TITLE
Add Terraform scrap

### DIFF
--- a/scraps/Terraform.md
+++ b/scraps/Terraform.md
@@ -1,0 +1,9 @@
+#[[Continuous Integration]] #[[Continuous Delivery]]
+
+HashiCorp 製の [[Infrastructure as Code]] ツール。API を宣言的な設定ファイルにコード化し、インフラの作成・変更・バージョン管理を安全かつ予測可能に行う
+
+- provider がクラウド / SaaS の API を抽象化し、低レベル（compute / storage / network）から高レベル（DNS・SaaS 機能）まで同じ記法で扱う
+- 設定は HCL で記述し、現状を state ファイルで追跡。`write → plan → apply` のワークフローで `plan` が適用前の差分を提示する
+- 2023-08 にライセンスを MPL 2.0 → BUSL 1.1（source-available の非 OSS）へ変更
+
+<https://developer.hashicorp.com/terraform>


### PR DESCRIPTION
## 概要

HashiCorp 製の Infrastructure as Code ツール `Terraform` の scrap を1件追加。

リポジトリ横断ガバナンスの catch-up の一環で、宣言的・継続ガバナンス層の基盤ツールとして ingest（safe-settings #283 に続く）。

## 内容

- `scraps/Terraform.md` を新規追加
- ローカル規約に従い **「それが何か」に限定**: provider による抽象化 / HCL / state / `write → plan → apply` / 2023-08 の MPL→BUSL ライセンス変遷
- GitHub provider 等の応用は本 scrap に書かず、別の具体 scrap へ委譲
- リンク: `[[Infrastructure as Code]]`（concrete→abstract）。タグ: `#[[Continuous Integration]]` `#[[Continuous Delivery]]`

## レビューでの確認・修正点

- `[[DevOps]]` は GitHub topics（`infrastructure-as-code` / `cloud` / `cloud-management`）に無い未確認カテゴリのため**不採用**（公式根拠のあるリンクのみ）
- OpenTofu は Terraform の兄弟（同具象）で concrete→abstract 規律に反するため**言及せず**（ライセンス変遷の事実のみ保持）
- broken-link lint: 0 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)