### PR TITLE
Add cicd-sensor scrap

### DIFF
--- a/scraps/cicd-sensor.md
+++ b/scraps/cicd-sensor.md
@@ -1,0 +1,20 @@
+#[[Security]] #[[Cloud Native]] #[[Continuous Integration]]
+
+[[GitHub Actions]] / GitLab CI/CD のジョブを[[eBPF]]でカーネルレベルに監視し、実行時の[[サプライチェーン攻撃]]を検出するオープンソースのランタイムセキュリティセンサー（"Think EDR, but for CI/CD Pipelines"）
+
+CI/CD が握る認証情報・署名鍵・トークンを狙う攻撃に対し、汚染された依存がジョブ内で「何を実行したか」のランタイム可視性と事後調査の手段を与える
+
+検出の仕組み:
+
+- プロセス系譜分析 - 例として `npm install` から派生したプロセスによる認証情報アクセス
+- シグナル相関 - 例として 1 ジョブ内での複数カテゴリの認証情報アクセス
+
+構成要素:
+
+- Sensor - eBPF ベースのランタイムモニタ
+- Action - GitHub Actions 統合。run ごとにレポートと build attestation を生成
+- Manager - ログを S3 / GCS / Pub/Sub 等のクラウドシンクへルーティング（データはユーザー管理下）
+
+2026 年時点で pre-release・活発に開発中
+
+<https://github.com/cicd-sensor/cicd-sensor>


### PR DESCRIPTION
## 概要

[[cicd-sensor]] scrap を追加。GitHub Actions / GitLab CI/CD 向けのオープンソース eBPF ランタイムセキュリティセンサー（"Think EDR, but for CI/CD Pipelines"）。

## 背景

cicd-sensor のキャッチアップを行い、公式ソース（GitHub repo・docs）で grounding した上で `/ingest` 経由で作成。

## 内容

- 新規 scrap `scraps/cicd-sensor.md`
- タグ: `#[[Security]] #[[Cloud Native]] #[[Continuous Integration]]`（[[Trivy]] と同構成）
- outbound cross-link: `[[eBPF]]` / `[[サプライチェーン攻撃]]` / `[[GitHub Actions]]`
- 「それが何か」に絞り、use case 列挙は回避。CVE-2025-30066 / tj-actions compromise への相互リンクは向き・捏造回避の観点から張らず

## 検証

- broken-link lint: 新 scrap に問題なし
- outbound リンク 3 件すべて既存 scrap に解決
- inbound mention なし（新語のため妥当）

Source: <https://github.com/cicd-sensor/cicd-sensor>

🤖 Generated with [Claude Code](https://claude.com/claude-code)