### PR TITLE
Add scrap: GitHub Code Quality

### DIFF
--- a/scraps/GitHub Code Quality.md
+++ b/scraps/GitHub Code Quality.md
@@ -1,0 +1,11 @@
+#[[Programming]] #[[Continuous Integration]]
+
+[[GitHub]]公式のコード品質機能。Code scanning を拡張し、Pull Request 上でコード品質の問題を検出して修正提案までを提供する。
+
+- 2025 年に public preview として公開。GitHub Team / Enterprise Cloud の組織リポジトリのみ対応（Enterprise Server 非対応）で、別途 Copilot / Code Security ライセンスは不要
+- ルールベース解析（CodeQL エンジン）と AI 解析の 2 系統で、保守性・信頼性・パフォーマンス・複雑度・重複/デッドコード・テストカバレッジなどを検出する
+- 指摘は PR 上にインライン表示され、[[GitHub Copilot]]によるワンクリック autofix と reliability/maintainability スコアを提示する
+- スキャンは[[GitHub Actions]]上で実行され、Actions minutes を消費する
+- [[適応度関数]]のコード品質カテゴリに該当する
+
+<https://docs.github.com/en/code-security/concepts/about-code-quality>


### PR DESCRIPTION
## 概要

GitHub 公式のコード品質機能 **GitHub Code Quality**（2025 public preview）を `/ingest` で取り込んだ scrap を追加。

## 変更内容

- `scraps/GitHub Code Quality.md` を新規作成（top-level / ctx なし、`GitHub Actions` `GitHub Copilot` と同じ命名規約）
- 本文: Code scanning の拡張、CodeQL ＋ AI 解析の2系統、PR 上のインライン指摘と Copilot autofix、Team / Enterprise Cloud 限定、といった「それが何か」に絞った記述

## リンク設計

- **アウトバウンド（具体→抽象）**: `[[GitHub]]` / `[[GitHub Copilot]]` / `[[GitHub Actions]]` / `[[適応度関数]]`
- `[[適応度関数]]` のコード品質カテゴリを `[[SonarQube]]` と共有する抽象ハブとして利用
- **インバウンド**: なし。`Code Quality` / `コード品質` の既存言及（適応度関数・SonarQube・Aikido Platform）は一般概念または他製品のスキャン分類のため、リンク化は見送り
- `CodeQL` は未 scrap 化のため broken-link を避けて平文で記載

## 検証

- タグ `#[[Programming]]` `#[[Continuous Integration]]` はいずれも既存タグ
- `scraps lint --rule broken-link` は新規 scrap でクリーン（既存の `[[IAM]]` 警告のみで本変更とは無関係）

出典: <https://docs.github.com/en/code-security/concepts/about-code-quality>

🤖 Generated with [Claude Code](https://claude.com/claude-code)